### PR TITLE
Fix article_id tracking to use initialArticle.id + admin edit article when the route [id] is an SEO slug.

### DIFF
--- a/frontend/src/app/[locale]/article/[id]/article-client.tsx
+++ b/frontend/src/app/[locale]/article/[id]/article-client.tsx
@@ -73,7 +73,7 @@ export default function ArticlePageClient({ id, locale, initialArticle, initialS
 
         await apiClient.trackUserBehavior({
           session_id: sessionId,
-          article_id: parseInt(id),
+          article_id: initialArticle.id,
           interaction_type: 'view',
           reading_time: 0,
           scroll_depth: 0,
@@ -141,7 +141,7 @@ export default function ArticlePageClient({ id, locale, initialArticle, initialS
             // Track reading time using the API client
             await apiClient.trackUserBehavior({
               session_id: sessionId,
-              article_id: parseInt(id),
+              article_id: initialArticle.id,
               interaction_type: 'view',
               reading_time: readingTime,
               scroll_depth: scrollDepth,
@@ -216,7 +216,7 @@ export default function ArticlePageClient({ id, locale, initialArticle, initialS
             <div className="flex items-center gap-2">
               {/* Admin Edit Button */}
               {isAuthenticated && user && (
-                <Link href={`/admin/articles/${id}`}>
+                <Link href={`/admin/articles/${initialArticle.id}`}>
                   <Button
                     variant="outline"
                     size="sm"


### PR DESCRIPTION
- Fix article_id tracking to use initialArticle.id instead of SEO id
- fix edit article for admin with id instead of SEO id.